### PR TITLE
Update keycloak-ingress.yaml

### DIFF
--- a/keycloak-ingress.yaml
+++ b/keycloak-ingress.yaml
@@ -3,9 +3,10 @@ kind: Ingress
 metadata:
   name: auth-ingress
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "https"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
       - fake


### PR DESCRIPTION
- proxy-buffer-size added to prevent 502 error
- ingress class name is not annotation anymore. They moved it into spec.ingressClassName.